### PR TITLE
feat: Implement initial 2D drawing generation framework

### DIFF
--- a/generators/svg_generator.py
+++ b/generators/svg_generator.py
@@ -1,0 +1,19 @@
+# Placeholder for svg_generator.py
+class SVGGenerator:
+    def generate_bridge_elevation(self, design_data: dict) -> str:
+        # 生成桥梁立面图SVG
+        return f"<svg width='800' height='600'><text x='10' y='20'>Bridge Elevation: {design_data.get('name', 'N/A')}</text></svg>"
+
+    def generate_girder_section(self, girder_data: dict) -> str:
+        # 生成主梁截面图SVG
+        return f"<svg width='400' height='300'><text x='10' y='20'>Girder Section: {girder_data.get('type', 'N/A')}</text></svg>"
+
+    def generate_pier_drawing(self, pier_data: dict) -> str:
+        # 生成桥墩图纸SVG
+        return f"<svg width='500' height='700'><text x='10' y='20'>Pier Drawing: {pier_data.get('id', 'N/A')}</text></svg>"
+
+    def add_dimensions(self, svg_content: str, dimensions: list) -> str:
+        # 添加尺寸标注
+        # This is a simplified placeholder. Real implementation would parse and modify SVG.
+        dimension_svg = "".join([f"<text x='{d.get('x', 0)}' y='{d.get('y', 0)}'>{d.get('text', '')}</text>" for d in dimensions])
+        return svg_content.replace("</svg>", f"{dimension_svg}</svg>")

--- a/services/drawing_service.py
+++ b/services/drawing_service.py
@@ -1,0 +1,124 @@
+# Placeholder for drawing_service.py
+from generators.svg_generator import SVGGenerator
+from templates.drawing_templates import get_populated_template
+import datetime
+
+class DrawingService:
+    def __init__(self):
+        self.svg_generator = SVGGenerator()
+        # In a real application, an LLM client would be initialized here.
+        # For example: self.llm_client = SomeLLMClient()
+
+    def _get_llm_drawing_instructions(self, bridge_design: dict, drawing_type: str, scale: float) -> dict:
+        """
+        Simulates calling an LLM to get drawing instructions.
+        In a real implementation, this would format DRAWING_PROMPT and send it to an LLM.
+        """
+        print(f"Simulating LLM call for: {drawing_type} with scale {scale}")
+        # Placeholder instructions - a real LLM would return detailed structured data
+        if drawing_type == "bridge_elevation":
+            return {
+                "main_lines": [{"x1": 50, "y1": 100, "x2": 750, "y2": 100, "type": "solid", "width": 3}],
+                "dimensions": [{"text": "100m", "x": 400, "y": 120}],
+                "annotations": [{"text": "Main Girder", "x": 400, "y": 90}],
+                "title_block_info": {"drawing_title": "Bridge Elevation", "scale": str(scale), "date": datetime.date.today().isoformat()},
+                "technical_notes": "All dimensions are in mm unless otherwise noted."
+            }
+        elif drawing_type == "girder_section":
+             return {
+                "main_lines": [{"x1": 50, "y1": 50, "x2": 150, "y2": 50, "type": "solid", "width": 2}], # Top
+                             # Add more lines for a box section for example
+                "dimensions": [{"text": "500mm", "x": 100, "y": 40}],
+                "reinforcement": [{"bar_type": "H16", "count": 5, "location": "top_layer"}],
+                "title_block_info": {"drawing_title": "Girder Section", "scale": str(scale), "date": datetime.date.today().isoformat()},
+            }
+        # Add more cases for other drawing_types
+        return {
+            "title_block_info": {"drawing_title": f"Placeholder: {drawing_type}", "scale": str(scale), "date": datetime.date.today().isoformat()},
+            "drawing_content": f"<text x='10' y='50'>Placeholder content for {drawing_type}</text>"
+        }
+
+
+    def generate_drawings(self, bridge_design: dict, drawing_types: list[str], scale: float = 1.0) -> dict:
+        """
+        Generates drawings based on bridge design data.
+        Simulates LLM interaction and SVG generation.
+        """
+        drawings = {}
+
+        for drawing_type in drawing_types:
+            # 1. Get drawing instructions from LLM (simulated)
+            # llm_instructions = self._get_llm_drawing_instructions(bridge_design, drawing_type, scale)
+
+            # For now, we'll use a simplified approach directly calling SVGGenerator methods
+            # and populating templates.
+
+            svg_content_placeholder = f"<text x='30' y='60'>Content for {drawing_type}</text>" # Default placeholder
+            template_data = {
+                "width": 800, "height": 600, # Default dimensions
+                "drawing_title": f"Unsupported: {drawing_type}",
+                "scale": str(scale),
+                "date": datetime.date.today().isoformat(),
+                "drawing_content": svg_content_placeholder
+            }
+
+            if drawing_type == "bridge_elevation_view": # Matches API response key
+                # Simulate data that would come from LLM or design_data processing
+                elevation_data = bridge_design.get("elevation_data", {"name": "Generic Bridge"})
+                generated_svg_part = self.svg_generator.generate_bridge_elevation(elevation_data)
+                template_data.update({
+                    "drawing_title": "Bridge Elevation View",
+                    "drawing_content": generated_svg_part # This is a full SVG, might need to extract its content
+                                                        # or the generator should return partial content.
+                                                        # For now, let's assume generator returns content to be embedded.
+                })
+                # For simplicity, let's assume generator methods return embeddable SVG content strings
+                # and templates are basic wrappers. A more robust solution would have generators
+                # build up an SVG document structure.
+                # For now, the generator methods return full SVG, so we just use that directly.
+                drawings[drawing_type] = self.svg_generator.generate_bridge_elevation(elevation_data)
+
+            elif drawing_type == "girder_section_view": # Example
+                girder_data = bridge_design.get("girder_data", {"type": "Typical Girder"})
+                # raw_svg = self.svg_generator.generate_girder_section(girder_data)
+                # In a real case, dimensions would come from LLM or calculations
+                # dimensions_to_add = llm_instructions.get("dimensions", [])
+                # drawings[drawing_type] = self.svg_generator.add_dimensions(raw_svg, dimensions_to_add)
+                drawings[drawing_type] = self.svg_generator.generate_girder_section(girder_data)
+
+
+            elif drawing_type == "pier_section_view": # Example
+                pier_data = bridge_design.get("pier_data", {"id": "Pier P1"})
+                drawings[drawing_type] = self.svg_generator.generate_pier_drawing(pier_data)
+
+            # Fallback for other types or if direct generation is not set up
+            else:
+                # Use a generic template for other types
+                # This part demonstrates using the template system more directly
+                template_data["drawing_title"] = f"Drawing: {drawing_type}"
+                # llm_instructions_for_template = self._get_llm_drawing_instructions(bridge_design, drawing_type, scale)
+                # template_data["drawing_content"] = llm_instructions_for_template.get("drawing_content", svg_content_placeholder)
+                # drawings[drawing_type] = get_populated_template("general_arrangement", template_data)
+
+                # For now, just a simple placeholder if not explicitly handled
+                 drawings[drawing_type] = f"<svg width='600' height='400'><text x='10' y='20'>Placeholder for {drawing_type}</text></svg>"
+
+
+        return drawings
+
+DRAWING_PROMPT = """
+基于以下桥梁设计数据，生成详细的SVG绘图指令：
+
+设计数据：{bridge_design}
+图纸类型：{drawing_type}
+比例要求：{scale}
+
+请输出包含以下内容的SVG绘图指令：
+1. 主体结构线条（坐标、线型、线宽）
+2. 尺寸标注（位置、数值、样式）
+3. 材料标注（文字、位置、引出线）
+4. 图例和标题栏
+5. 技术要求说明
+
+确保符合《房屋建筑CAD制图统一规则》标准。
+"""

--- a/static/js/svg_viewer.js
+++ b/static/js/svg_viewer.js
@@ -1,0 +1,238 @@
+// Placeholder for static/js/svg_viewer.js
+
+class SVGViewer {
+    constructor(containerId) {
+        this.container = document.getElementById(containerId);
+        if (!this.container) {
+            console.error(`SVGViewer: Container with id '${containerId}' not found.`);
+            return;
+        }
+        this.svgElement = null;
+        this.zoomLevel = 1;
+        this.panX = 0;
+        this.panY = 0;
+
+        // Basic styling for the container
+        this.container.style.overflow = 'hidden'; // Important for panning
+        this.container.style.position = 'relative'; // For absolute positioning of controls
+        this.container.style.border = '1px solid #ccc';
+    }
+
+    loadSVG(svgString) {
+        if (this.svgElement) {
+            this.container.removeChild(this.svgElement);
+        }
+        // Create a temporary div to parse the SVG string
+        const tempDiv = document.createElement('div');
+        tempDiv.innerHTML = svgString;
+        this.svgElement = tempDiv.querySelector('svg');
+
+        if (this.svgElement) {
+            this.container.appendChild(this.svgElement);
+            this.svgElement.style.transformOrigin = '0 0'; // Set transform origin for zooming
+            this.resetView();
+            this.setupEventListeners();
+        } else {
+            console.error("SVGViewer: No SVG element found in the provided string.");
+            this.container.innerHTML = "<p>Error loading SVG.</p>";
+        }
+    }
+
+    updateTransform() {
+        if (this.svgElement) {
+            this.svgElement.style.transform = `translate(${this.panX}px, ${this.panY}px) scale(${this.zoomLevel})`;
+        }
+    }
+
+    zoom(factor) {
+        this.zoomLevel *= factor;
+        this.updateTransform();
+        console.log(`Zoom level: ${this.zoomLevel}`);
+    }
+
+    pan(deltaX, deltaY) {
+        this.panX += deltaX;
+        this.panY += deltaY;
+        this.updateTransform();
+        console.log(`Pan: X=${this.panX}, Y=${this.panY}`);
+    }
+
+    resetView() {
+        this.zoomLevel = 1;
+        this.panX = 0;
+        this.panY = 0;
+        if (this.svgElement) {
+            // Attempt to fit SVG to container - very basic
+            const containerWidth = this.container.clientWidth;
+            const containerHeight = this.container.clientHeight;
+            const svgWidth = this.svgElement.width.baseVal.value;
+            const svgHeight = this.svgElement.height.baseVal.value;
+
+            if (svgWidth > 0 && svgHeight > 0) {
+                const scaleX = containerWidth / svgWidth;
+                const scaleY = containerHeight / svgHeight;
+                this.zoomLevel = Math.min(scaleX, scaleY) * 0.95; // Add a little padding
+            }
+        }
+        this.updateTransform();
+    }
+
+    measureDistance() {
+        // Placeholder for measurement logic
+        alert("Measurement tool: Click two points to measure distance (not implemented).");
+        console.log("Measurement tool activated (placeholder).");
+    }
+
+    printSVG() {
+        if (!this.svgElement) {
+            alert("No SVG loaded to print.");
+            return;
+        }
+        // This is a very basic print. More sophisticated printing might involve rendering to canvas.
+        const printWindow = window.open('', '_blank');
+        printWindow.document.write('<html><head><title>Print SVG</title></head><body>');
+        printWindow.document.write(this.svgElement.outerHTML);
+        printWindow.document.write('</body></html>');
+        printWindow.document.close(); // Necessary for some browsers.
+        printWindow.onload = function() { // Wait for content to load before printing
+            printWindow.print();
+            printWindow.close();
+        };
+        console.log("Print function called.");
+    }
+
+    exportSVG() {
+        if (!this.svgElement) {
+            alert("No SVG loaded to export.");
+            return;
+        }
+        const svgData = this.svgElement.outerHTML;
+        const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'drawing.svg';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+        console.log("Export SVG function called.");
+    }
+
+    setupEventListeners() {
+        // Placeholder for event listeners (e.g., mouse drag for panning)
+        let isPanning = false;
+        let lastMouseX, lastMouseY;
+
+        if (!this.svgElement) return;
+
+        this.svgElement.addEventListener('mousedown', (e) => {
+            // Pan on middle mouse button or Ctrl + Left Click
+            if (e.button === 1 || (e.button === 0 && e.ctrlKey)) {
+                isPanning = true;
+                lastMouseX = e.clientX;
+                lastMouseY = e.clientY;
+                this.svgElement.style.cursor = 'grabbing';
+                e.preventDefault();
+            }
+        });
+
+        this.container.addEventListener('mousemove', (e) => {
+            if (isPanning) {
+                const deltaX = e.clientX - lastMouseX;
+                const deltaY = e.clientY - lastMouseY;
+                lastMouseX = e.clientX;
+                lastMouseY = e.clientY;
+                this.pan(deltaX / this.zoomLevel, deltaY / this.zoomLevel); // Adjust pan speed by zoom
+            }
+        });
+
+        this.container.addEventListener('mouseup', (e) => {
+            if (isPanning) {
+                isPanning = false;
+                this.svgElement.style.cursor = 'grab';
+            }
+        });
+
+        this.container.addEventListener('mouseleave', (e) => { // Stop panning if mouse leaves container
+            if (isPanning) {
+                isPanning = false;
+                this.svgElement.style.cursor = 'grab';
+            }
+        });
+
+        this.container.addEventListener('wheel', (e) => {
+            e.preventDefault(); // Prevent page scrolling
+            const zoomFactor = e.deltaY < 0 ? 1.1 : 1 / 1.1; // Zoom in or out
+
+            // Zoom towards mouse pointer
+            const rect = this.svgElement.getBoundingClientRect();
+            const mouseX = e.clientX - rect.left; // Mouse X relative to SVG
+            const mouseY = e.clientY - rect.top;  // Mouse Y relative to SVG
+
+            // Adjust pan to keep mouse position stable after zoom
+            this.panX = mouseX - (mouseX - this.panX) * zoomFactor;
+            this.panY = mouseY - (mouseY - this.panY) * zoomFactor;
+
+            this.zoom(zoomFactor);
+        });
+
+        // Add basic controls (example)
+        this.addControls();
+    }
+
+    addControls() {
+        const controlsDiv = document.createElement('div');
+        controlsDiv.style.position = 'absolute';
+        controlsDiv.style.top = '10px';
+        controlsDiv.style.left = '10px';
+        controlsDiv.style.zIndex = '1000'; // Ensure controls are on top
+        controlsDiv.style.background = 'rgba(255,255,255,0.8)';
+        controlsDiv.style.padding = '5px';
+        controlsDiv.style.borderRadius = '5px';
+
+        const zoomInButton = document.createElement('button');
+        zoomInButton.textContent = '+';
+        zoomInButton.onclick = () => this.zoom(1.2);
+        controlsDiv.appendChild(zoomInButton);
+
+        const zoomOutButton = document.createElement('button');
+        zoomOutButton.textContent = '-';
+        zoomOutButton.onclick = () => this.zoom(1/1.2);
+        controlsDiv.appendChild(zoomOutButton);
+
+        const resetButton = document.createElement('button');
+        resetButton.textContent = 'Reset';
+        resetButton.onclick = () => this.resetView();
+        controlsDiv.appendChild(resetButton);
+
+        const measureButton = document.createElement('button');
+        measureButton.textContent = 'Measure';
+        measureButton.onclick = () => this.measureDistance();
+        controlsDiv.appendChild(measureButton);
+
+        const printButton = document.createElement('button');
+        printButton.textContent = 'Print';
+        printButton.onclick = () => this.printSVG();
+        controlsDiv.appendChild(printButton);
+
+        const exportButton = document.createElement('button');
+        exportButton.textContent = 'Export SVG';
+        exportButton.onclick = () => this.exportSVG();
+        controlsDiv.appendChild(exportButton);
+
+        this.container.appendChild(controlsDiv);
+    }
+}
+
+// Example Usage (optional, for testing):
+// document.addEventListener('DOMContentLoaded', () => {
+//     const viewer = new SVGViewer('svgContainer'); // Assuming you have a <div id="svgContainer"></div>
+//     const exampleSVG = `
+//         <svg width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+//             <rect x="50" y="50" width="100" height="100" fill="blue" />
+//             <circle cx="250" cy="100" r="40" fill="red" />
+//             <text x="60" y="180">Sample SVG</text>
+//         </svg>`;
+//     viewer.loadSVG(exampleSVG);
+// });

--- a/templates/drawing_templates.py
+++ b/templates/drawing_templates.py
@@ -1,0 +1,63 @@
+# Placeholder for drawing_templates.py
+
+# In a real application, these would be more complex SVG templates
+# with placeholders for data insertion.
+
+GENERAL_ARRANGEMENT_TEMPLATE = """
+<svg width="{width}" height="{height}" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        .title {{ font-family: Arial, sans-serif; font-size: 20px; font-weight: bold; }}
+        .label {{ font-family: Arial, sans-serif; font-size: 12px; }}
+        .structure {{ stroke: black; stroke-width: 2; fill: none; }}
+        .dimension {{ stroke: red; stroke-width: 1; fill: none; }}
+        .dim-text {{ font-family: Arial, sans-serif; font-size: 10px; fill: red; }}
+    </style>
+    <rect x="0" y="0" width="{width}" height="{height}" fill="white" stroke="black"/>
+
+    <!-- Title Block -->
+    <rect x="{width_minus_200}" y="{height_minus_100}" width="190" height="90" fill="none" stroke="black"/>
+    <text x="{width_minus_195}" y="{height_minus_80}" class="title">Drawing Title: {drawing_title}</text>
+    <text x="{width_minus_195}" y="{height_minus_60}" class="label">Scale: {scale}</text>
+    <text x="{width_minus_195}" y="{height_minus_40}" class="label">Date: {date}</text>
+
+    <!-- Drawing Content Placeholder -->
+    {drawing_content}
+
+</svg>
+"""
+
+SECTION_VIEW_TEMPLATE = """
+<svg width="{width}" height="{height}" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        .title {{ font-family: Arial, sans-serif; font-size: 18px; font-weight: bold; }}
+        .label {{ font-family: Arial, sans-serif; font-size: 10px; }}
+        .rebar {{ stroke: blue; stroke-width: 1; }}
+        .concrete {{ stroke: gray; stroke-width: 2; fill: lightgray; }}
+        .dimension {{ stroke: red; stroke-width: 1; fill: none; }}
+        .dim-text {{ font-family: Arial, sans-serif; font-size: 10px; fill: red; }}
+    </style>
+    <rect x="0" y="0" width="{width}" height="{height}" fill="white" stroke="black"/>
+
+    <!-- Title Block -->
+    <rect x="{width_minus_150}" y="{height_minus_80}" width="140" height="70" fill="none" stroke="black"/>
+    <text x="{width_minus_145}" y="{height_minus_65}" class="title">{drawing_title}</text>
+    <text x="{width_minus_145}" y="{height_minus_50}" class="label">Scale: {scale}</text>
+
+    <!-- Drawing Content Placeholder -->
+    {drawing_content}
+
+</svg>
+"""
+
+# Helper to populate templates - in a real scenario, this would be more sophisticated
+def get_populated_template(template_name: str, data: dict) -> str:
+    if template_name == "general_arrangement":
+        # Calculate dynamic positions for title block
+        data['width_minus_200'] = data.get('width', 800) - 200
+        data['height_minus_100'] = data.get('height', 600) - 100
+        return GENERAL_ARRANGEMENT_TEMPLATE.format(**data)
+    elif template_name == "section_view":
+        data['width_minus_150'] = data.get('width', 400) - 150
+        data['height_minus_80'] = data.get('height', 300) - 80
+        return SECTION_VIEW_TEMPLATE.format(**data)
+    return f"<svg><!-- Unknown template: {template_name} --></svg>"


### PR DESCRIPTION
Adds the foundational structure for generating 2D engineering drawings in SVG format.

Includes:
- Placeholder DrawingService, SVGGenerator, and drawing templates.
- API endpoint /api/generate_drawings in FastAPI.
- Basic SVG viewer with zoom, pan, print, and export capabilities (measurement as placeholder).

This commit establishes the core files and services. Further work is needed to implement detailed LLM integration, sophisticated SVG generation according to engineering standards, and full functionality for all drawing types and viewer features.